### PR TITLE
Update drops.lua

### DIFF
--- a/client/drops.lua
+++ b/client/drops.lua
@@ -32,6 +32,14 @@ end
 
 -- Events
 
+RegisterNetEvent('qb-inventory:client:removeDropTarget', function(dropId)
+    while not NetworkDoesNetworkIdExist(dropId) do Wait(10) end
+    local bag = NetworkGetEntityFromNetworkId(dropId)
+    while not DoesEntityExist(bag) do Wait(10) end
+    --Run exsport to remove entity target bag
+    exports['qb-target']:RemoveTargetEntity(bag)
+end)
+
 RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
     while not NetworkDoesNetworkIdExist(dropId) do Wait(10) end
     local bag = NetworkGetEntityFromNetworkId(dropId)
@@ -51,29 +59,32 @@ RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
                 icon = 'fas fa-hand-pointer',
                 label = 'Pick up bag',
                 action = function()
-                    AttachEntityToEntity(
-                        bag,
-                        PlayerPedId(),
-                        GetPedBoneIndex(PlayerPedId(), Config.ItemDropObjectBone),
-                        Config.ItemDropObjectOffset[1].x,
-                        Config.ItemDropObjectOffset[1].y,
-                        Config.ItemDropObjectOffset[1].z,
-                        Config.ItemDropObjectOffset[2].x,
-                        Config.ItemDropObjectOffset[2].y,
-                        Config.ItemDropObjectOffset[2].z,
-                        true, true, false, true, 1, true
-                    )
-                    bagObject = bag
-                    holdingDrop = true
-                    heldDrop = newDropId
-                    exports['qb-core']:DrawText('Press [G] to drop the bag')
+                    if not holdingDrop then 
+                        AttachEntityToEntity(
+                            bag,
+                            PlayerPedId(),
+                            GetPedBoneIndex(PlayerPedId(), Config.ItemDropObjectBone),
+                            Config.ItemDropObjectOffset[1].x,
+                            Config.ItemDropObjectOffset[1].y,
+                            Config.ItemDropObjectOffset[1].z,
+                            Config.ItemDropObjectOffset[2].x,
+                            Config.ItemDropObjectOffset[2].y,
+                            Config.ItemDropObjectOffset[2].z,
+                            true, true, false, true, 1, true
+                        )
+                        bagObject = bag
+                        holdingDrop = true
+                        heldDrop = newDropId
+                        exports['qb-core']:DrawText('Press [G] to drop the bag')
+                    else
+                        QBCore.Functions.Notify("Your already holding a bag, Go Drop it!", "error", 5500)
+                    end
                 end,
             }
         },
         distance = 2.5,
     })
 end)
-
 -- NUI Callbacks
 
 RegisterNUICallback('DropItem', function(item, cb)


### PR DESCRIPTION
This was added as part of the multi drop holding conundrum and to ensure there can only be one drop held at a time by the player.  When drop has no items it's deleted this also removes the target on the bag before it's deleted.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
